### PR TITLE
:hammer: Change deprecated instruction MAINTAINER to LABEL

### DIFF
--- a/php-fpm/Dockerfile
+++ b/php-fpm/Dockerfile
@@ -1,5 +1,5 @@
 FROM php:7.1-fpm
-MAINTAINER Wouter De Schuyter <wouter.de.schuyter@gmail.com>
+LABEL maintainer="Wouter De Schuyter <wouter.de.schuyter@gmail.com>"
 
 RUN apt-get update
 


### PR DESCRIPTION
Hey, I'm really glad to use your simple docker-compose package. Very useful.

And I'm going to open a pull request, which corrects the deprecated instruction "MAINTAINER" to "LABEL" in php-fpm/Dockerfile.

Refer to this: https://docs.docker.com/engine/reference/builder/#maintainer-deprecated